### PR TITLE
Fix Linear AgentActivity GraphQL fields

### DIFF
--- a/src/takopi_linear/client.py
+++ b/src/takopi_linear/client.py
@@ -219,9 +219,6 @@ class LinearClient:
             success
             agentActivity {
               id
-              type
-              body
-              createdAt
             }
           }
         }


### PR DESCRIPTION
Linear GraphQL now rejects querying `type`/`body` on `AgentActivity`.

This updates the `agentActivityCreate` mutation selection set to only request `id`, which is all the transport uses.

Test:
- `python -m compileall -q src/takopi_linear`
