### PR TITLE
Handle kai-gateway AgentSession event types

### DIFF
--- a/tests/test_webhook_parsing.py
+++ b/tests/test_webhook_parsing.py
@@ -5,8 +5,14 @@ from takopi_linear.backend import (
     _extract_issue_title,
     _extract_prompt_body,
     _extract_session_id,
+    _normalize_event_type,
     _unwrap_payload,
 )
+
+def test_normalizes_agent_session_event_types() -> None:
+    assert _normalize_event_type("AgentSessionEvent", "created") == "agent_session.created"
+    assert _normalize_event_type("agentsessionevent.created", None) == "agent_session.created"
+    assert _normalize_event_type("agentsessionevent.prompted", None) == "agent_session.prompted"
 
 
 def test_extracts_agent_session_created_fields() -> None:
@@ -35,4 +41,3 @@ def test_extracts_prompted_body_from_agent_activity() -> None:
     raw = _unwrap_payload(payload)
     assert _extract_session_id(raw) == "sess_1"
     assert _extract_prompt_body(raw) == "please continue"
-


### PR DESCRIPTION
Fixes Linear sessions showing “did not respond” when events are ingested via kai-gateway.

kai-gateway stores events with `event_type` like `agentsessionevent.created` / `agentsessionevent.prompted` (action embedded). The Linear transport backend only handled the native webhook shape (`type: AgentSessionEvent` + `action`), so it was ignoring these events and marking them done without sending any agent activity.

Changes:
- Normalize `agentsessionevent.*` -> `agent_session.*` in `backend._handle_event`.
- Add a small compatibility shim for `takopi.config.resolve_config_path` (some versions don’t expose it).
- Add tests for event type normalization.

Test:
- `pytest`
