### PR TITLE
Fix Linear AgentActivity content encoding

### DIFF
--- a/src/takopi_linear/bridge.py
+++ b/src/takopi_linear/bridge.py
@@ -132,23 +132,20 @@ def _activity_from_message(message: RenderedMessage, *, default_type: AgentActiv
         action = message.extra.get("action")
         parameter = message.extra.get("parameter")
         result = message.extra.get("result")
-        content: dict[str, Any] = {"type": "action", "action": {}}
-        if isinstance(action, str):
-            content["action"]["action"] = action
-        if isinstance(parameter, str):
-            content["action"]["parameter"] = parameter
-        if isinstance(result, str):
-            content["action"]["result"] = result
-        if not content["action"]:
-            content["action"] = {"action": "message", "parameter": message.text}
+        content: dict[str, Any] = {"type": "action"}
+        if isinstance(action, str) and action.strip():
+            content["action"] = action.strip()
+        if isinstance(parameter, str) and parameter.strip():
+            content["parameter"] = parameter.strip()
+        if isinstance(result, str) and result.strip():
+            content["result"] = result.strip()
+        if "action" not in content:
+            content["action"] = "message"
+        if "parameter" not in content and message.text.strip():
+            content["parameter"] = message.text.strip()
         return _ActivitySpec(type=activity_type, content=content, ephemeral=ephemeral)
 
-    content = {
-        "type": activity_type,
-        activity_type: {
-            "body": message.text,
-        },
-    }
+    content = {"type": activity_type, "body": message.text}
     return _ActivitySpec(type=activity_type, content=content, ephemeral=ephemeral)
 
 

--- a/tests/test_bridge.py
+++ b/tests/test_bridge.py
@@ -1,0 +1,56 @@
+from __future__ import annotations
+
+from takopi.transport import RenderedMessage
+
+from takopi_linear.bridge import _activity_from_message
+
+
+def test_renders_thought_activity_content() -> None:
+    spec = _activity_from_message(
+        RenderedMessage(text="hello", extra={"activity_type": "thought", "ephemeral": True}),
+        default_type="thought",
+    )
+    assert spec.content == {"type": "thought", "body": "hello"}
+    assert spec.ephemeral is True
+
+
+def test_renders_response_activity_content() -> None:
+    spec = _activity_from_message(
+        RenderedMessage(text="done", extra={"activity_type": "response"}),
+        default_type="thought",
+    )
+    assert spec.content == {"type": "response", "body": "done"}
+    assert spec.ephemeral is None
+
+
+def test_renders_action_activity_content() -> None:
+    spec = _activity_from_message(
+        RenderedMessage(
+            text="fallback",
+            extra={
+                "activity_type": "action",
+                "action": "run_tests",
+                "parameter": "pytest -q",
+                "result": "ok",
+                "ephemeral": True,
+            },
+        ),
+        default_type="thought",
+    )
+    assert spec.content == {
+        "type": "action",
+        "action": "run_tests",
+        "parameter": "pytest -q",
+        "result": "ok",
+    }
+    assert spec.ephemeral is True
+
+
+def test_renders_action_activity_content_fallback() -> None:
+    spec = _activity_from_message(
+        RenderedMessage(text="ping", extra={"activity_type": "action", "ephemeral": True}),
+        default_type="thought",
+    )
+    assert spec.content == {"type": "action", "action": "message", "parameter": "ping"}
+    assert spec.ephemeral is True
+


### PR DESCRIPTION
Linear’s `agentActivityCreate` expects `content` to be a flat JSON object (e.g. `{type: "response", body: "..."}`), but the transport was sending a nested structure (e.g. `{type: "response", response: {body: "..."}}`), causing “Invalid activity content” errors and no replies in Linear.

Changes:
- Build flat `content` payloads for thought/response/error/elicitation/prompt.
- Build flat action payloads (`action`, `parameter`, `result`).
- Add unit tests covering content encoding.

Test:
- `pytest`
