### PR TITLE
Fix webhook prompt parsing

### DIFF
--- a/src/takopi_linear/poller.py
+++ b/src/takopi_linear/poller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 from collections.abc import Callable
+import json
 from typing import Any, cast
 
 import anyio
@@ -95,6 +96,16 @@ class GatewayPoller:
             if not isinstance(row, dict):
                 continue
             payload = row.get("payload")
+            if isinstance(payload, (bytes, bytearray)):
+                try:
+                    payload = payload.decode("utf-8")
+                except Exception:
+                    payload = {}
+            if isinstance(payload, str):
+                try:
+                    payload = json.loads(payload)
+                except json.JSONDecodeError:
+                    payload = {}
             if not isinstance(payload, dict):
                 payload = {}
             events.append(

--- a/tests/test_webhook_parsing.py
+++ b/tests/test_webhook_parsing.py
@@ -3,11 +3,13 @@ from __future__ import annotations
 from takopi_linear.backend import (
     _extract_issue_project_id,
     _extract_issue_title,
+    _extract_issue_title_from_prompt_context,
     _extract_prompt_body,
     _extract_session_id,
     _normalize_event_type,
     _unwrap_payload,
 )
+
 
 def test_normalizes_agent_session_event_types() -> None:
     assert _normalize_event_type("AgentSessionEvent", "created") == "agent_session.created"
@@ -41,3 +43,48 @@ def test_extracts_prompted_body_from_agent_activity() -> None:
     raw = _unwrap_payload(payload)
     assert _extract_session_id(raw) == "sess_1"
     assert _extract_prompt_body(raw) == "please continue"
+
+
+def test_extracts_prompted_body_from_agent_activity_content_body() -> None:
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": "prompted",
+        "data": {
+            "agentSession": {"id": "sess_1"},
+            "agentActivity": {"content": {"type": "message", "body": "hello from content"}},
+        },
+    }
+    raw = _unwrap_payload(payload)
+    assert _extract_session_id(raw) == "sess_1"
+    assert _extract_prompt_body(raw) == "hello from content"
+
+
+def test_extracts_prompted_body_from_agent_activity_content_action_message_parameter() -> None:
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": "prompted",
+        "agentSession": {"id": "sess_1"},
+        "agentActivity": {"content": {"type": "action", "action": "message", "parameter": "hello param"}},
+    }
+    raw = _unwrap_payload(payload)
+    assert _extract_prompt_body(raw) == "hello param"
+
+
+def test_extracts_issue_title_from_prompt_context_title_tag() -> None:
+    payload = {"promptContext": "<issue><title>@fix/test Extract title</title></issue>"}
+    raw = _unwrap_payload(payload)
+    assert _extract_issue_title(raw) is None
+    assert _extract_issue_title_from_prompt_context(raw) == "@fix/test Extract title"
+
+
+def test_extracts_fields_with_snake_case_keys() -> None:
+    payload = {
+        "agent_session": {
+            "id": "sess_1",
+            "issue": {"title": "Snake case title", "project_id": "proj_1"},
+        }
+    }
+    raw = _unwrap_payload(payload)
+    assert _extract_session_id(raw) == "sess_1"
+    assert _extract_issue_title(raw) == "Snake case title"
+    assert _extract_issue_project_id(raw) == "proj_1"


### PR DESCRIPTION
Fixes cases where AgentSession events were interpreted as the literal prompt "continue" by improving payload unwrapping + prompt extraction (agentActivity.content/body, snake_case keys) and decoding JSON payload strings from kai-gateway. Adds tests.