### PR TITLE
Fix missing prompt in Linear webhook payload

### DIFF
--- a/src/takopi_linear/client.py
+++ b/src/takopi_linear/client.py
@@ -151,6 +151,33 @@ class LinearClient:
             raise LinearApiError("Missing issue in response")
         return issue  # type: ignore[return-value]
 
+    async def get_agent_activity(self, activity_id: str) -> LinearAgentActivity:
+        query = """
+        query AgentActivity($id: String!) {
+          agentActivity(id: $id) {
+            id
+            content {
+              __typename
+              ... on AgentActivityThoughtContent { body }
+              ... on AgentActivityPromptContent { body }
+              ... on AgentActivityElicitationContent { body }
+              ... on AgentActivityResponseContent { body }
+              ... on AgentActivityErrorContent { body }
+              ... on AgentActivityActionContent { action parameter result }
+            }
+          }
+        }
+        """
+        data = await self.graphql(
+            query,
+            variables={"id": activity_id},
+            operation_name="AgentActivity",
+        )
+        activity = data.get("agentActivity")
+        if not isinstance(activity, dict):
+            raise LinearApiError("Missing agentActivity in response")
+        return activity  # type: ignore[return-value]
+
     async def update_issue(self, issue_id: str, **fields: Any) -> LinearIssue:
         query = """
         mutation IssueUpdate($id: String!, $input: IssueUpdateInput!) {

--- a/src/takopi_linear/types.py
+++ b/src/takopi_linear/types.py
@@ -49,6 +49,7 @@ class LinearAgentActivity(TypedDict, total=False):
     id: str
     type: str
     body: str
+    content: object
     createdAt: str
 
 
@@ -56,4 +57,3 @@ class LinearAgentSession(TypedDict, total=False):
     id: str
     state: str
     issue: LinearIssue | None
-

--- a/tests/test_stop.py
+++ b/tests/test_stop.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from typing import Any, cast
 
 import pytest
@@ -82,3 +83,109 @@ async def test_stop_event_requests_cancel_for_running_session() -> None:
     assert transport.sent
     assert transport.sent[-1][0] == "sess_1"
     assert "Stop requested" in transport.sent[-1][1].text
+
+
+class _FakeRunner:
+    engine = "fake"
+
+    def is_resume_line(self, line: str) -> bool:
+        _ = line
+        return False
+
+    def extract_resume(self, text: str | None):
+        _ = text
+        return None
+
+    def run(self, prompt: str, resume):
+        _ = (prompt, resume)
+        return None
+
+
+class _FakeRuntime:
+    def __init__(self) -> None:
+        self.seen_text: str | None = None
+
+    def resolve_message(self, *, text: str, reply_text, ambient_context, chat_id):
+        _ = (reply_text, ambient_context, chat_id)
+        self.seen_text = text
+        return cast(
+            Any,
+            type(
+                "_Resolved",
+                (),
+                {"prompt": text, "engine_override": None, "resume_token": None, "context": None},
+            )(),
+        )
+
+    def resolve_runner(self, *, resume_token, engine_override):
+        _ = (resume_token, engine_override)
+        return cast(Any, type("_Entry", (), {"runner": _FakeRunner(), "available": True, "issue": None})())
+
+    def resolve_run_cwd(self, context):
+        _ = context
+        return Path("/tmp")
+
+    def format_context_line(self, context):
+        _ = context
+        return ""
+
+    def is_resume_line(self, line: str) -> bool:
+        _ = line
+        return False
+
+
+class _FakeClient:
+    def __init__(self) -> None:
+        self.seen_activity_id: str | None = None
+
+    async def get_agent_activity(self, activity_id: str):
+        self.seen_activity_id = activity_id
+        return {"id": activity_id, "content": {"__typename": "AgentActivityPromptContent", "body": "fetched prompt"}}
+
+
+@pytest.mark.anyio
+async def test_prompted_event_fetches_prompt_body_when_missing(monkeypatch: pytest.MonkeyPatch) -> None:
+    async def fake_handle_message(*args, **kwargs):
+        _ = (args, kwargs)
+        return None
+
+    monkeypatch.setattr("takopi_linear.backend.handle_message", fake_handle_message)
+
+    transport = _FakeTransport()
+    exec_cfg = ExecBridgeConfig(transport=transport, presenter=_FakePresenter(), final_notify=False)
+    settings = LinearTransportSettings(
+        oauth_token="token",
+        app_id="app",
+        gateway_database_url="postgresql://example",
+    )
+    client = _FakeClient()
+    runtime = _FakeRuntime()
+
+    event = GatewayEvent(
+        id="e1",
+        source="linear",
+        event_type="AgentSessionEvent",
+        payload={
+            "type": "AgentSessionEvent",
+            "action": "prompted",
+            "agentSession": {"id": "sess_1"},
+            "agentActivity": {"id": "act_1"},
+        },
+        external_id=None,
+        created_at=None,
+    )
+
+    await _handle_event(
+        event=event,
+        runtime=cast(Any, runtime),
+        exec_cfg=exec_cfg,
+        client=cast(Any, client),
+        settings=settings,
+        project_map={},
+        sessions={},
+        default_engine_override=None,
+    )
+
+    assert client.seen_activity_id == "act_1"
+    assert runtime.seen_text == "fetched prompt"
+    assert any("Acknowledged" in msg.text for _, msg in transport.sent)

--- a/tests/test_webhook_parsing.py
+++ b/tests/test_webhook_parsing.py
@@ -63,6 +63,28 @@ def test_extracts_prompted_body_from_agent_activity_content_body() -> None:
     assert _extract_prompt_body(raw) == "hello from content"
 
 
+def test_extracts_prompted_body_from_agent_activity_content_nested_message_body() -> None:
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": "prompted",
+        "agentSession": {"id": "sess_1"},
+        "agentActivity": {"content": {"type": "message", "message": {"body": "hello nested"}}},
+    }
+    raw = _unwrap_payload(payload)
+    assert _extract_prompt_body(raw) == "hello nested"
+
+
+def test_extracts_prompted_body_from_agent_activity_content_json_string() -> None:
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": "prompted",
+        "agentSession": {"id": "sess_1"},
+        "agentActivity": {"content": '{"type":"message","message":{"body":"hello json"}}'},
+    }
+    raw = _unwrap_payload(payload)
+    assert _extract_prompt_body(raw) == "hello json"
+
+
 def test_extracts_prompted_body_from_agent_activity_content_action_message_parameter() -> None:
     payload = {
         "type": "AgentSessionEvent",
@@ -72,6 +94,19 @@ def test_extracts_prompted_body_from_agent_activity_content_action_message_param
     }
     raw = _unwrap_payload(payload)
     assert _extract_prompt_body(raw) == "hello param"
+
+
+def test_extracts_prompted_body_from_agent_activity_content_nested_action_message_parameter() -> None:
+    payload = {
+        "type": "AgentSessionEvent",
+        "action": "prompted",
+        "agentSession": {"id": "sess_1"},
+        "agentActivity": {
+            "content": {"type": "action", "action": {"action": "message", "parameter": "hello nested param"}}
+        },
+    }
+    raw = _unwrap_payload(payload)
+    assert _extract_prompt_body(raw) == "hello nested param"
 
 
 def test_extracts_issue_title_from_prompt_context_title_tag() -> None:


### PR DESCRIPTION
Fixes cases where kai-gateway/Linear webhooks omit agentActivity body/content.

- Parse additional agentActivity.content shapes (nested message/action + JSON string)
- Fallback: fetch prompt body via Linear API when only agentActivity.id is present
- Adds regression tests