### PR TITLE
Handle minimal kai-gateway payloads by fetching agent session snapshot

### DIFF
--- a/src/takopi_linear/backend.py
+++ b/src/takopi_linear/backend.py
@@ -344,6 +344,43 @@ async def _maybe_fetch_prompt_from_linear(
     return _extract_activity_body(activity)
 
 
+def _extract_prompt_from_agent_session_snapshot(snapshot: object) -> str | None:
+    if not isinstance(snapshot, dict):
+        return None
+    activities = snapshot.get("activities")
+    if not isinstance(activities, dict):
+        return None
+    nodes = activities.get("nodes")
+    if not isinstance(nodes, list):
+        return None
+
+    best_body: str | None = None
+    best_created_at: str = ""
+
+    for node in nodes:
+        if not isinstance(node, dict):
+            continue
+        content = node.get("content")
+        typename = content.get("__typename") if isinstance(content, dict) else None
+        if typename not in {"AgentActivityPromptContent", "AgentActivityActionContent"}:
+            continue
+
+        body = _extract_activity_body(node)
+        if body is None:
+            continue
+
+        created_at = (
+            _coerce_text(node.get("createdAt"))
+            or _coerce_text(node.get("created_at"))
+            or ""
+        )
+        if best_body is None or created_at > best_created_at:
+            best_body = body
+            best_created_at = created_at
+
+    return best_body
+
+
 @dataclass(slots=True)
 class _SessionState:
     resume: ResumeToken | None = None
@@ -636,9 +673,20 @@ async def _handle_event(
 
         issue_id: str | None = None
         issue_from_api: dict[str, Any] | None = None
+        agent_session_snapshot: dict[str, Any] | None = None
 
         project_id = _extract_issue_project_id(payload)
         issue_title = _extract_issue_title(payload) or _extract_issue_title_from_prompt_context(payload)
+        prompt_from_payload = _extract_prompt_body(payload)
+
+        should_fetch_snapshot = False
+        if normalized == "agent_session.created" and (project_id is None or issue_title is None):
+            should_fetch_snapshot = True
+        if normalized == "agent_session.prompted":
+            if not prompt_from_payload and _extract_agent_activity_id(payload) is None:
+                should_fetch_snapshot = True
+            if state.context is None and project_id is None and project_map:
+                should_fetch_snapshot = True
 
         if normalized == "agent_session.created":
             issue_id = _extract_issue_id(payload)
@@ -653,18 +701,43 @@ async def _handle_event(
                 if isinstance(project, dict):
                     project_id = _coerce_text(project.get("id")) or project_id
 
+        if should_fetch_snapshot:
+            try:
+                agent_session_snapshot = await client.get_agent_session_snapshot(
+                    session_id,
+                    activities_last=20,
+                )
+            except LinearApiError:
+                agent_session_snapshot = None
+
+            if agent_session_snapshot is not None:
+                issue = agent_session_snapshot.get("issue")
+                if isinstance(issue, dict):
+                    issue_id = _coerce_text(issue.get("id")) or issue_id
+                    issue_title = _coerce_text(issue.get("title")) or issue_title
+                    project = issue.get("project")
+                    if isinstance(project, dict):
+                        project_id = _coerce_text(project.get("id")) or project_id
+
         if state.context is None and project_id and project_id in project_map:
             state.context = RunContext(project=project_map[project_id], branch=None)
 
-        if normalized == "agent_session.created":
-            if issue_title is None and issue_from_api is not None:
-                issue_title = _coerce_text(issue_from_api.get("title")) or issue_title
-            prompt = issue_title or _extract_prompt_body(payload)
-        else:
-            prompt = _extract_prompt_body(payload)
+        if normalized == "agent_session.created" and issue_title is None and issue_from_api is not None:
+            issue_title = _coerce_text(issue_from_api.get("title")) or issue_title
 
-        if not prompt:
-            prompt = await _maybe_fetch_prompt_from_linear(payload, client=client)
+        prompt_body = prompt_from_payload
+        if not prompt_body:
+            prompt_body = await _maybe_fetch_prompt_from_linear(payload, client=client)
+        if not prompt_body and agent_session_snapshot is not None:
+            prompt_body = _extract_prompt_from_agent_session_snapshot(agent_session_snapshot)
+
+        if normalized == "agent_session.created":
+            if issue_title and prompt_body and issue_title not in prompt_body:
+                prompt = f"{issue_title}\n\n{prompt_body}"
+            else:
+                prompt = prompt_body or issue_title
+        else:
+            prompt = prompt_body
 
         if not prompt:
             msg = (

--- a/tests/test_stop.py
+++ b/tests/test_stop.py
@@ -189,3 +189,123 @@ async def test_prompted_event_fetches_prompt_body_when_missing(monkeypatch: pyte
     assert client.seen_activity_id == "act_1"
     assert runtime.seen_text == "fetched prompt"
     assert any("Acknowledged" in msg.text for _, msg in transport.sent)
+
+
+class _FakeSnapshotClient:
+    def __init__(self) -> None:
+        self.seen_session_id: str | None = None
+
+    async def set_agent_plan(self, *, session_id: str, steps):
+        _ = (session_id, steps)
+        return None
+
+    async def get_agent_session_snapshot(self, session_id: str, *, activities_last: int = 10):
+        self.seen_session_id = session_id
+        _ = activities_last
+        return {
+            "id": session_id,
+            "issue": {"id": "iss_1", "title": "Snapshot issue", "project": {"id": "proj_1"}},
+            "activities": {
+                "nodes": [
+                    {
+                        "id": "act_1",
+                        "createdAt": "2026-02-22T15:46:48.125Z",
+                        "content": {"__typename": "AgentActivityPromptContent", "body": "snapshot prompt"},
+                    }
+                ]
+            },
+        }
+
+
+@pytest.mark.anyio
+async def test_prompted_event_fetches_prompt_from_session_snapshot_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_handle_message(*args, **kwargs):
+        _ = (args, kwargs)
+        return None
+
+    monkeypatch.setattr("takopi_linear.backend.handle_message", fake_handle_message)
+
+    transport = _FakeTransport()
+    exec_cfg = ExecBridgeConfig(transport=transport, presenter=_FakePresenter(), final_notify=False)
+    settings = LinearTransportSettings(
+        oauth_token="token",
+        app_id="app",
+        gateway_database_url="postgresql://example",
+    )
+    client = _FakeSnapshotClient()
+    runtime = _FakeRuntime()
+
+    event = GatewayEvent(
+        id="e1",
+        source="linear",
+        event_type="agentsessionevent.prompted",
+        payload={
+            "type": "agentsessionevent.prompted",
+            "data": {"agentSessionId": "sess_1"},
+        },
+        external_id=None,
+        created_at=None,
+    )
+
+    await _handle_event(
+        event=event,
+        runtime=cast(Any, runtime),
+        exec_cfg=exec_cfg,
+        client=cast(Any, client),
+        settings=settings,
+        project_map={"proj_1": "takopi-linear"},
+        sessions={},
+        default_engine_override=None,
+    )
+
+    assert client.seen_session_id == "sess_1"
+    assert runtime.seen_text == "snapshot prompt"
+
+
+@pytest.mark.anyio
+async def test_created_event_builds_prompt_from_issue_title_and_snapshot_prompt_when_missing(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def fake_handle_message(*args, **kwargs):
+        _ = (args, kwargs)
+        return None
+
+    monkeypatch.setattr("takopi_linear.backend.handle_message", fake_handle_message)
+
+    transport = _FakeTransport()
+    exec_cfg = ExecBridgeConfig(transport=transport, presenter=_FakePresenter(), final_notify=False)
+    settings = LinearTransportSettings(
+        oauth_token="token",
+        app_id="app",
+        gateway_database_url="postgresql://example",
+    )
+    client = _FakeSnapshotClient()
+    runtime = _FakeRuntime()
+
+    event = GatewayEvent(
+        id="e1",
+        source="linear",
+        event_type="agentsessionevent.created",
+        payload={
+            "type": "agentsessionevent.created",
+            "data": {"agentSessionId": "sess_1"},
+        },
+        external_id=None,
+        created_at=None,
+    )
+
+    await _handle_event(
+        event=event,
+        runtime=cast(Any, runtime),
+        exec_cfg=exec_cfg,
+        client=cast(Any, client),
+        settings=settings,
+        project_map={"proj_1": "takopi-linear"},
+        sessions={},
+        default_engine_override=None,
+    )
+
+    assert client.seen_session_id == "sess_1"
+    assert runtime.seen_text == "Snapshot issue\n\nsnapshot prompt"


### PR DESCRIPTION
Root cause: kai-gateway DB events currently store only agentSessionId (no agentActivity/body), so takopi-linear can't extract the prompt from webhook payloads.

Fix:
- Fallback to Linear GraphQL  snapshot (issue + recent activities) to recover prompt + project mapping
- Keep existing agentActivity-id fallback when available
- Add regression tests for created/prompted minimal payloads